### PR TITLE
Avoid request headers for GET, be fast in CORS

### DIFF
--- a/lib/bz.js
+++ b/lib/bz.js
@@ -102,8 +102,10 @@ BugzillaClient.prototype = {
       // in a browser
       var req = new XMLHttpRequest();
       req.open(method, url, true);
-      req.setRequestHeader("Accept", "application/json")
-      req.setRequestHeader("Content-type", "application/json");
+      req.setRequestHeader("Accept", "application/json");
+      if (method.toUpperCase() !== "GET") {
+        req.setRequestHeader("Content-type", "application/json");
+      }
       req.onreadystatechange = function (event) {
         if (req.readyState == 4) {
           that.handleResponse(null, req, callback, field);


### PR DESCRIPTION
If one isn't very lax about the headers to send with requests, CORS goes into a preflight mode, sending an OPTION request for every real request.

At least for GET, we don't need this, and this makes bzhome query bzapi half as much.

https://developer.mozilla.org/En/HTTP_access_control
