### PR TITLE
xhr module is now located in api-utils

### DIFF
--- a/lib/bz.js
+++ b/lib/bz.js
@@ -93,7 +93,7 @@ BugzillaClient.prototype = {
     body = JSON.stringify(body);
      
     try {
-      var XMLHttpRequest = require("api-utils/xhr").XMLHttpRequest; // Addon SDK
+      XMLHttpRequest = require("api-utils/xhr").XMLHttpRequest; // Addon SDK
     }
     catch(e) {}
 


### PR DESCRIPTION
In order to get this package to work with SDK 1.3, you need to include api-utils in the require statement.
