### PR TITLE
Use /latest API endpoint, as 0.9 is going away in two weeks.

### DIFF
--- a/lib/bz.js
+++ b/lib/bz.js
@@ -3,8 +3,8 @@ var BugzillaClient = function(options) {
   this.username = options.username;
   this.password = options.password;
   this.apiUrl = options.url || 
-    (options.test ? "https://api-dev.bugzilla.mozilla.org/test/0.9/"
-                  : "https://api-dev.bugzilla.mozilla.org/0.9/");
+    (options.test ? "https://api-dev.bugzilla.mozilla.org/test/latest/"
+                  : "https://api-dev.bugzilla.mozilla.org/latest/");
 }
 
 BugzillaClient.prototype = {


### PR DESCRIPTION
http://blog.gerv.net/2012/03/bugzilla-api-1-1-released/
