### PR TITLE
Allow a timeout to be optionally specified

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,13 +27,14 @@ bugzilla.getBug(678223, function(error, bug) {
 
 # API
 `bz.createClient(options)`
-creates a new Bugzilla API client, optionally takes options like the REST API url and username + password:
+creates a new Bugzilla API client, optionally takes options like the REST API url, username + password, and timeout in milliseconds:
 
 ```javascript
 var bugzilla = bz.createClient({
   url: "https://api-dev.bugzilla.mozilla.org/test/0.9/",
   username: 'bugs@bugmail.com',
-  password: 'secret'
+  password: 'secret',
+  timeout: 30000
 });
 ```
 

--- a/test/sanity/error.js
+++ b/test/sanity/error.js
@@ -18,3 +18,14 @@ bugzilla.createBug({ /* empty bug */ },
     assert.ok(error);
   }
 );
+
+bugzilla = bz.createClient({
+  url: "https://api-dev.bugzilla.mozilla.org/test/latest/",
+  username: "testbzapi@gmail.com",
+  password: "password",
+  timeout: 1 // ensure the request will timeout
+});
+
+bugzilla.getConfiguration(function (error, config) {
+  assert.equal("timeout", error);
+});


### PR DESCRIPTION
[m-cMerge](http://www.graememcc.co.uk/m-cmerge) uses bz.js to handle BzAPI requests. When https://bugzilla.mozilla.org has issues (such as the data centre issues yesterday) it would be nice to fail gracefully instead of waiting for a callback that will never come!

Points to note:
- The default timeout is 0 (no timeout) to mimic current behaviour
- For node, I now explicitly construct the parameters for **request**, and separately add the  timeout if non-zero. Reading the code for **request**, it appears a timeout of zero is ignored, and could be safely passed in, but this behaviour is not explicitly documented, so I don't want to rely on it.
- Ontimeout is fired after readystatechange, which meant checking for a null status in onreadystatechange. This in turn required an onerror handler to ensure handleResponse still gets called in other null status cases. I ignored abort, as there's no way for the caller to trigger an abort, and no code within bz.js would trigger it.
- In browser, I used the same strings ("error", "timeout") that jQuery Ajax would return out of selfish convenience!
- However, I didn't want to throw away potentially useful error text in node. This meant I couldn't ensure the same error text in both browser and node, and thus prevented the writing of a test for the error case.
