### PR TITLE
Strip trailing slash if present in apiURL: individual API calls duplicate it

### DIFF
--- a/bz.js
+++ b/bz.js
@@ -4,8 +4,11 @@ var BugzillaClient = function(options) {
   this.password = options.password;
   this.timeout = options.timeout || 0;
   this.apiUrl = options.url || 
-    (options.test ? "https://api-dev.bugzilla.mozilla.org/test/latest/"
-                  : "https://api-dev.bugzilla.mozilla.org/latest/");
+    (options.test ? "https://api-dev.bugzilla.mozilla.org/test/latest"
+                  : "https://api-dev.bugzilla.mozilla.org/latest");
+  var i = this.apiUrl.length - 1, lastChar = this.apiUrl.charAt(i);
+  if (lastChar == '/')
+    this.apiUrl = this.apiUrl(0, i);
 }
 
 BugzillaClient.prototype = {


### PR DESCRIPTION
Utterly trivial change: you can [blame](http://logbot.glob.com.au/?c=mozilla%23developers&s=6+Nov+2012&e=6+Nov+2012&h=#c426151) [edmorley](http://logbot.glob.com.au/?c=mozilla%23developers&s=11+Jan+2013&e=11+Jan+2013&h=#c487073) for this!
