### PR TITLE
The BzAPI compatibility extension has been pushed to production

### DIFF
--- a/bz.js
+++ b/bz.js
@@ -4,8 +4,8 @@ var BugzillaClient = function(options) {
   this.password = options.password;
   this.timeout = options.timeout || 0;
   this.apiUrl = options.url ||
-    (options.test ? "https://api-dev.bugzilla.mozilla.org/test/latest"
-                  : "https://api-dev.bugzilla.mozilla.org/latest");
+    (options.test ? "https://bugzilla-dev.allizom.org/bzapi"
+                  : "https://bugzilla.mozilla.org/bzapi");
   this.apiUrl = this.apiUrl.replace(/\/$/, "");
 }
 


### PR DESCRIPTION
The BzAPI compatibility extension has been pushed to the production
Bugzilla system for testing and feedback. If you are using the
BzAPI proxy please test your client code against the production site.

Change:
https://api-dev.bugzilla.mozilla.org/latest
to
https://bugzilla.mozilla.org/bzapi

dkl
