### PR TITLE
updated xhr require path for jetpack support

### DIFF
--- a/bz.js
+++ b/bz.js
@@ -101,7 +101,7 @@ BugzillaClient.prototype = {
     body = JSON.stringify(body);
 
     try {
-      XMLHttpRequest = require("xhr").XMLHttpRequest; // Addon SDK
+      XMLHttpRequest = require("sdk/net/xhr").XMLHttpRequest; // Addon SDK
     }
     catch(e) {}
 


### PR DESCRIPTION
This makes it a bit easier to use this library with Jetpack - we changed the paths a long time ago, our bad :)
