### PR TITLE
Make sure bz.js sends username as the 'login' param.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -319,7 +319,7 @@ export var BugzillaClient = class {
       params.token = this._auth.token;
     }
     else if (this.username && this.password) {
-      params.username = this.username;
+      params.login = this.username;
       params.password = this.password;
     }
 


### PR DESCRIPTION
I think this is needed to make sure bz.js doesn't send both 'login' and 'username' parameters to bugzilla.