### PR TITLE
Update host for bugzilla configuration url

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -270,7 +270,7 @@ export var BugzillaClient = class {
     let that = this;
 
     var req = new XMLHttpRequest();
-    req.open('GET', 'https://api-dev.bugzilla.mozilla.org/latest/configuration', true);
+    req.open('GET', 'https://bugzilla.mozilla.org/latest/configuration', true);
     req.setRequestHeader("Accept", "application/json");
     req.onreadystatechange = function (event) {
       if (req.readyState == 4 && req.status != 0) {


### PR DESCRIPTION
Loading the bugzilla configuration fails since bugzilla moved to AWS last weekend, see e.g. https://bugzilla.mozilla.org/show_bug.cgi?id=1448608 api-dev.bmo redirects to bmo. Removing "api-dev." returns the bugzilla configuration.